### PR TITLE
Add Main CLI feature for user to input hex color string and return ratio and WCAG levels.

### DIFF
--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -29,4 +29,17 @@ module RubyColorContrastChecker
     print message
     gets.chomp
   end
+
+  def self.print_data(data)
+    output = <<~MLS
+      Contrast Ratio    : #{data["ratio"]}
+
+      Level AA          : #{data["AA"].upcase}
+      Level AA (Large)  : #{data["AALarge"].upcase}
+      Level AAA         : #{data["AAA"].upcase}
+      Level AAA (Large) : #{data["AAALarge"].upcase}
+    MLS
+
+    puts output
+  end
 end

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -3,6 +3,7 @@
 require_relative "ruby_color_contrast_checker/version"
 
 module RubyColorContrastChecker
-  class Error < StandardError; end
-  # Your code goes here...
+  def self.valid_hex?(hex)
+    !!(hex =~ /^[a-f0-9]{6}$/i) || !!(hex =~ /^[a-f0-9]{3}$/i)
+  end
 end

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -24,4 +24,9 @@ module RubyColorContrastChecker
     chars = hex.chars
     "#{chars[0]}#{chars[0]}#{chars[1]}#{chars[1]}#{chars[2]}#{chars[2]}"
   end
+
+  def self.prompt_input(message)
+    print message
+    gets.chomp
+  end
 end

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -6,11 +6,15 @@ require "net/http"
 require "json"
 
 module RubyColorContrastChecker
-  def self.valid_hex?(hex)
+  def self.run
+    Class.new { extend RubyColorContrastChecker }.run
+  end
+
+  def valid_hex?(hex)
     !!(hex =~ /^[a-f0-9]{6}$/i) || !!(hex =~ /^[a-f0-9]{3}$/i)
   end
 
-  def self.fetch_data(hex1, hex2)
+  def fetch_data(hex1, hex2)
     hex1 = convert_3hex_to_6hex(hex1) if hex1.length == 3
     hex2 = convert_3hex_to_6hex(hex2) if hex2.length == 3
 
@@ -20,17 +24,17 @@ module RubyColorContrastChecker
     JSON.parse(response.body)
   end
 
-  def self.convert_3hex_to_6hex(hex)
+  def convert_3hex_to_6hex(hex)
     chars = hex.chars
     "#{chars[0]}#{chars[0]}#{chars[1]}#{chars[1]}#{chars[2]}#{chars[2]}"
   end
 
-  def self.prompt_input(message)
+  def prompt_input(message)
     print message
     gets.chomp
   end
 
-  def self.print_data(data)
+  def print_data(data)
     output = <<~MLS
       Contrast Ratio    : #{data["ratio"]}
 
@@ -43,7 +47,7 @@ module RubyColorContrastChecker
     puts output
   end
 
-  def self.run
+  def run
     loop do
       puts
       first = prompt_input("Enter the first hex color string: \n> #")

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -11,6 +11,9 @@ module RubyColorContrastChecker
   end
 
   def self.fetch_data(hex1, hex2)
+    hex1 = convert_3hex_to_6hex(hex1) if hex1.length == 3
+    hex2 = convert_3hex_to_6hex(hex2) if hex2.length == 3
+
     uri = URI("https://webaim.org/resources/contrastchecker/?fcolor=#{hex1}&bcolor=#{hex2}&api")
     response = Net::HTTP.get_response(uri)
 

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -16,4 +16,9 @@ module RubyColorContrastChecker
 
     JSON.parse(response.body)
   end
+
+  def self.convert_3hex_to_6hex(hex)
+    chars = hex.chars
+    "#{chars[0]}#{chars[0]}#{chars[1]}#{chars[1]}#{chars[2]}#{chars[2]}"
+  end
 end

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 require_relative "ruby_color_contrast_checker/version"
+require "uri"
+require "net/http"
+require "json"
 
 module RubyColorContrastChecker
   def self.valid_hex?(hex)
     !!(hex =~ /^[a-f0-9]{6}$/i) || !!(hex =~ /^[a-f0-9]{3}$/i)
+  end
+
+  def self.fetch_data(hex1, hex2)
+    uri = URI("https://webaim.org/resources/contrastchecker/?fcolor=#{hex1}&bcolor=#{hex2}&api")
+    response = Net::HTTP.get_response(uri)
+
+    JSON.parse(response.body)
   end
 end

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -42,4 +42,24 @@ module RubyColorContrastChecker
 
     puts output
   end
+
+  def self.run
+    loop do
+      puts
+      first = prompt_input("Enter the first hex color string: \n> #")
+      second = prompt_input("Enter the second hex color string: \n> #")
+      puts
+
+      if !valid_hex?(first) || !valid_hex?(second)
+        puts "The Hex color code is invalid."
+      else
+        data = fetch_data(first, second)
+        print_data(data)
+      end
+
+      puts
+      input = prompt_input("Continue? (yes / no) ")
+      break if input.downcase == "no"
+    end
+  end
 end

--- a/lib/ruby_color_contrast_checker.rb
+++ b/lib/ruby_color_contrast_checker.rb
@@ -14,7 +14,7 @@ module RubyColorContrastChecker
     hex1 = convert_3hex_to_6hex(hex1) if hex1.length == 3
     hex2 = convert_3hex_to_6hex(hex2) if hex2.length == 3
 
-    uri = URI("https://webaim.org/resources/contrastchecker/?fcolor=#{hex1}&bcolor=#{hex2}&api")
+    uri = URI.parse("https://webaim.org/resources/contrastchecker/?fcolor=#{hex1}&bcolor=#{hex2}&api")
     response = Net::HTTP.get_response(uri)
 
     JSON.parse(response.body)

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -26,8 +26,20 @@ RSpec.describe RubyColorContrastChecker do
   end
 
   context "self.fetch_data method" do
-    it "takes 2 valid hex string arguments and returns hash of the json response" do
+    it "takes 2 valid 6-digit hex string arguments and returns hash of the json response" do
       actual = sut.fetch_data("000000", "FFFFFF")
+
+      expect(actual).to eq({
+        "ratio" => "21",
+        "AA" => "pass",
+        "AALarge" => "pass",
+        "AAA" => "pass",
+        "AAALarge" => "pass"
+      })
+    end
+
+    it "takes 2 valid 3-digit hex string arguments and returns hash of the json response" do
+      actual = sut.fetch_data("000", "FFF")
 
       expect(actual).to eq({
         "ratio" => "21",

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -63,4 +63,14 @@ RSpec.describe RubyColorContrastChecker do
       end
     end
   end
+
+  context "self.prompt_input method" do
+    it "takes a message, prints the message and returns the user input" do
+      allow(sut).to receive(:gets).and_return("ABC")
+      message = "Please enter ABC"
+
+      expect(sut.prompt_input(message)).to eq("ABC")
+      expect { sut.prompt_input(message) }.to output(message).to_stdout
+    end
+  end
 end

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -96,4 +96,34 @@ RSpec.describe RubyColorContrastChecker do
       expect { sut.print_data(data) }.to output(expected).to_stdout
     end
   end
+
+  context "self.run method" do
+    it "start the cli app, input valid hex strings, print data and exit app" do
+      data = {data: "test"}
+
+      allow(sut).to receive(:prompt_input).and_return("000", "FFF", "no")
+      expect(sut).to receive(:fetch_data).with("000", "FFF").and_return(data)
+      expect(sut).to receive(:print_data).with(data)
+
+      sut.run
+    end
+
+    it "start the cli app, input invalid hex strings, print error message and exit app" do
+      allow(sut).to receive(:prompt_input).and_return("000", "GGG", "no")
+      expect(sut).not_to receive(:fetch_data)
+      expect(sut).not_to receive(:print_data)
+
+      expect { sut.run }.to output("\n\nThe Hex color code is invalid.\n\n").to_stdout
+    end
+
+    it "start the cli app and keep looping until user enters 'no' to exit the app" do
+      data = {data: "test"}
+
+      allow(sut).to receive(:prompt_input).and_return("000", "FFF", "yes", "000", "FFF", "no")
+      expect(sut).to receive(:fetch_data).twice.with("000", "FFF").and_return(data)
+      expect(sut).to receive(:print_data).twice.with(data)
+
+      sut.run
+    end
+  end
 end

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe RubyColorContrastChecker do
-  sut = RubyColorContrastChecker
-
   it "has a version number" do
     expect(RubyColorContrastChecker::VERSION).not_to be nil
   end
 
-  context "self.valid_hex? method" do
+  it "has a self.run method to start the app" do
+    app_mock = Class.new { extend RubyColorContrastChecker }
+
+    allow(Class).to receive(:new).and_return(app_mock)
+
+    expect(app_mock).to receive(:run)
+
+    RubyColorContrastChecker.run
+  end
+
+  let(:sut) { Class.new { extend RubyColorContrastChecker } }
+
+  context "valid_hex? method" do
     it "returns true if the 6-digits Hex string provided is valid" do
       expect(sut.valid_hex?("FFFFFF")).to be(true)
     end
@@ -25,7 +35,7 @@ RSpec.describe RubyColorContrastChecker do
     end
   end
 
-  context "self.fetch_data method" do
+  context "fetch_data method" do
     it "takes 2 valid 6-digit hex string arguments and returns hash of the json response" do
       response = Net::HTTPSuccess.new(1.0, "200", "OK")
       hex1 = "000000"
@@ -57,7 +67,7 @@ RSpec.describe RubyColorContrastChecker do
     end
   end
 
-  context "self.convert_3hex_to_6hex method" do
+  context "convert_3hex_to_6hex method" do
     it "takes a valid 3-digit hex string argument and returns the 6-digit hex string" do
       inputs = ["000", "555", "aaa", "FFF"]
       expected = ["000000", "555555", "aaaaaa", "FFFFFF"]
@@ -70,7 +80,7 @@ RSpec.describe RubyColorContrastChecker do
     end
   end
 
-  context "self.prompt_input method" do
+  context "prompt_input method" do
     it "takes a message, prints the message and returns the user input" do
       allow(sut).to receive(:gets).and_return("ABC")
       message = "Please enter ABC"
@@ -80,7 +90,7 @@ RSpec.describe RubyColorContrastChecker do
     end
   end
 
-  context "self.print_data method" do
+  context "print_data method" do
     it "takes in the data hash and print the data" do
       data = {
         "ratio" => "21",
@@ -103,7 +113,7 @@ RSpec.describe RubyColorContrastChecker do
     end
   end
 
-  context "self.run method" do
+  context "run method" do
     it "start the cli app, input valid hex strings, print data and exit app" do
       data = {data: "test"}
 

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -24,4 +24,18 @@ RSpec.describe RubyColorContrastChecker do
       expect(sut.valid_hex?("GGG")).to be(false)
     end
   end
+
+  context "self.fetch_data method" do
+    it "takes 2 valid hex string arguments and returns hash of the json response" do
+      actual = sut.fetch_data("000000", "FFFFFF")
+
+      expect(actual).to eq({
+        "ratio" => "21",
+        "AA" => "pass",
+        "AALarge" => "pass",
+        "AAA" => "pass",
+        "AAALarge" => "pass"
+      })
+    end
+  end
 end

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -73,4 +73,27 @@ RSpec.describe RubyColorContrastChecker do
       expect { sut.prompt_input(message) }.to output(message).to_stdout
     end
   end
+
+  context "self.print_data method" do
+    it "takes in the data hash and print the data" do
+      data = {
+        "ratio" => "21",
+        "AA" => "pass",
+        "AALarge" => "pass",
+        "AAA" => "pass",
+        "AAALarge" => "pass"
+      }
+
+      expected = <<~MLS
+        Contrast Ratio    : 21
+
+        Level AA          : PASS
+        Level AA (Large)  : PASS
+        Level AAA         : PASS
+        Level AAA (Large) : PASS
+      MLS
+
+      expect { sut.print_data(data) }.to output(expected).to_stdout
+    end
+  end
 end

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -27,27 +27,33 @@ RSpec.describe RubyColorContrastChecker do
 
   context "self.fetch_data method" do
     it "takes 2 valid 6-digit hex string arguments and returns hash of the json response" do
-      actual = sut.fetch_data("000000", "FFFFFF")
+      response = Net::HTTPSuccess.new(1.0, "200", "OK")
+      hex1 = "000000"
+      hex2 = "FFFFFF"
 
-      expect(actual).to eq({
-        "ratio" => "21",
-        "AA" => "pass",
-        "AALarge" => "pass",
-        "AAA" => "pass",
-        "AAALarge" => "pass"
-      })
+      expect(URI).to receive(:parse).with("https://webaim.org/resources/contrastchecker/?fcolor=#{hex1}&bcolor=#{hex2}&api").and_return("url")
+      expect(Net::HTTP).to receive(:get_response).with("url").and_return(response)
+      expect(response).to receive(:body).and_return("data")
+      expect(JSON).to receive(:parse).with("data").and_return("data")
+
+      actual = sut.fetch_data(hex1, hex2)
+
+      expect(actual).to eq("data")
     end
 
     it "takes 2 valid 3-digit hex string arguments and returns hash of the json response" do
-      actual = sut.fetch_data("000", "FFF")
+      response = Net::HTTPSuccess.new(1.0, "200", "OK")
+      hex1 = "000"
+      hex2 = "FFF"
 
-      expect(actual).to eq({
-        "ratio" => "21",
-        "AA" => "pass",
-        "AALarge" => "pass",
-        "AAA" => "pass",
-        "AAALarge" => "pass"
-      })
+      expect(URI).to receive(:parse).with("https://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=FFFFFF&api").and_return("url")
+      expect(Net::HTTP).to receive(:get_response).with("url").and_return(response)
+      expect(response).to receive(:body).and_return("data")
+      expect(JSON).to receive(:parse).with("data").and_return("data")
+
+      actual = sut.fetch_data(hex1, hex2)
+
+      expect(actual).to eq("data")
     end
   end
 

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -1,7 +1,27 @@
 # frozen_string_literal: true
 
 RSpec.describe RubyColorContrastChecker do
+  sut = RubyColorContrastChecker
+
   it "has a version number" do
     expect(RubyColorContrastChecker::VERSION).not_to be nil
+  end
+
+  context "self.valid_hex? method" do
+    it "returns true if the 6-digits Hex string provided is valid" do
+      expect(sut.valid_hex?("FFFFFF")).to be(true)
+    end
+
+    it "returns false if the 6-digits Hex string provided is invalid" do
+      expect(sut.valid_hex?("GGGGGG")).to be(false)
+    end
+
+    it "returns true if the 3-digits Hex string provided is valid" do
+      expect(sut.valid_hex?("000")).to be(true)
+    end
+
+    it "returns false if the 3-digits Hex string provided is invalid" do
+      expect(sut.valid_hex?("GGG")).to be(false)
+    end
   end
 end

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -114,9 +114,9 @@ RSpec.describe RubyColorContrastChecker do
   end
 
   context "run method" do
-    it "start the cli app, input valid hex strings, print data and exit app" do
-      data = {data: "test"}
+    data = {"ratio" => "21"}
 
+    it "start the cli app, input valid hex strings, print data and exit app" do
       allow(sut).to receive(:prompt_input).and_return("000", "FFF", "no")
       expect(sut).to receive(:fetch_data).with("000", "FFF").and_return(data)
       expect(sut).to receive(:print_data).with(data)
@@ -133,8 +133,6 @@ RSpec.describe RubyColorContrastChecker do
     end
 
     it "start the cli app and keep looping until user enters 'no' to exit the app" do
-      data = {data: "test"}
-
       allow(sut).to receive(:prompt_input).and_return("000", "FFF", "yes", "000", "FFF", "no")
       expect(sut).to receive(:fetch_data).twice.with("000", "FFF").and_return(data)
       expect(sut).to receive(:print_data).twice.with(data)

--- a/spec/ruby_color_contrast_checker_spec.rb
+++ b/spec/ruby_color_contrast_checker_spec.rb
@@ -38,4 +38,17 @@ RSpec.describe RubyColorContrastChecker do
       })
     end
   end
+
+  context "self.convert_3hex_to_6hex method" do
+    it "takes a valid 3-digit hex string argument and returns the 6-digit hex string" do
+      inputs = ["000", "555", "aaa", "FFF"]
+      expected = ["000000", "555555", "aaaaaa", "FFFFFF"]
+
+      inputs.each_with_index do |input, index|
+        actual = sut.convert_3hex_to_6hex(input)
+
+        expect(actual).to eq(expected[index])
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # Initialize SimpleCov before application code to track code coverage.
 require "simplecov"
-SimpleCov.start "rails"
+SimpleCov.start
 
 # frozen_string_literal: true
 


### PR DESCRIPTION
## Type of Change

<!--
Please delete options that are not relevant.
 -->

- [x] ✨ New Feature
- [x] ✅ New Test

## Description

<!--
Please include a summary of the changes and the link to the ticket (jira/canban board etc). Please also include relevant motivation and context. List any dependencies that are required for this change.
 -->
- add main feature to ask user for input of 2 hex strings, and return the ratio and WCAG levels for color contrast.

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 -->

- [x] CLI Process
![image](https://github.com/cheehwatang/ruby_color_contrast_checker/assets/81938708/f68f006c-1991-41c0-bd1f-bf399b67c464)

- [x] Test results
![image](https://github.com/cheehwatang/ruby_color_contrast_checker/assets/81938708/4c2ea7cd-a44b-4096-ba89-d02560f68ebb)


## Added or Updated Tests?

<!--
Please delete options that are not relevant.
 -->

- [x] 👍 Yes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
